### PR TITLE
[1.18.2-2.7.4+] Make sky dark again.

### DIFF
--- a/src/main/java/weather2/ClientWeatherHelper.java
+++ b/src/main/java/weather2/ClientWeatherHelper.java
@@ -162,7 +162,7 @@ public final class ClientWeatherHelper {
 		ClientTickHandler.getClientWeather();
 		ClientWeatherProxy weather = ClientWeatherProxy.get();
 		float rainAmount = weather.getVanillaRainAmount();
-		float visualDarknessAmplifier = 0.5F;
+		float visualDarknessAmplifier = 1.0F;
 		if (precipitating) {
 			mc.level.getLevelData().setRaining(rainAmount > 0);
 			mc.level.setRainLevel(rainAmount * visualDarknessAmplifier);


### PR DESCRIPTION
This restores compatibility with shaders and  custom resource packs so that the sky actually looks like it's storming and raining when a storm is active. 

Personally I'd like to just see it as 1.0F so that things like Complementary shaders fully cover the built-in cloud layer for the immersion of it actually being a real storm. I don't think we'd see the sun with a F5 tornado on the ground or hailing super-cell :P

I understand the want for a less dramatic effect but 1.0F kind of just makes the mod feel more alive so to speak, as you can see in these below screenshots comparing the two floats. Of course, it may also be reasonable to have the sky darken depending on if it's a rain storm, thunderstorm, or supercell. 0.5F if rain storm, 0.75F if thunderstorm, 1.0F if wind storm or above. Thanks! ^_^

### Darkness 0.5F - Sun is visible, not common for a tornadic supercell:
![2023-01-06_22 46 30](https://user-images.githubusercontent.com/16886014/211129837-e353aee6-d5df-4cd5-a243-9d98f1d9dd54.png)


### Darkness 1.0F - Looks more like a real supercell:
![2023-01-06_22 55 33](https://user-images.githubusercontent.com/16886014/211130116-49ce1df8-3538-4a3d-bd45-d9b279ed3984.png)



Edit: words are hard >.>, am not good at this github thing yet eheh