### PR TITLE
Fix 1.20.1 server crash regression on 2.8.1

### DIFF
--- a/src/main/java/weather2/weathersystem/storm/StormObject.java
+++ b/src/main/java/weather2/weathersystem/storm/StormObject.java
@@ -2459,10 +2459,10 @@ public class StormObject extends WeatherObject {
 
 			entity.setDeltaMovement(spinObject(entity.position(), entity.getDeltaMovement(), entity instanceof Player, dampenXZ, dampenY, false, grabAdj));
 
-			if (!ConfigTornado.Storm_Tornado_fallDamage || CoroUtilEntOrParticle.getMotionY(entity) > -0.8)
-			{
-				entity.fallDistance = 0F;
-			}
+			// if (!ConfigTornado.Storm_Tornado_fallDamage || CoroUtilEntOrParticle.getMotionY(entity) > -0.8)
+			// {
+			// 	entity.fallDistance = 0F;
+			// }
 
 			if (isFirenado) {
 				Vec3 posEnt = entity.position();


### PR DESCRIPTION
The server will always crash when a tornado is spawning on 2.8.1, I back-traced the error from the server crash and looked at the git line history from  2.7.7 to 2.8.1

Server error when a tornado spawns:
```
[20:36:46] [Server thread/ERROR] [minecraft/MinecraftServer]: Encountered an unexpected exception
java.lang.RuntimeException: Attempted to load class net/minecraft/client/multiplayer/ClientLevel for invalid dist DEDICATED_SERVER
	at net.minecraftforge.fml.loading.RuntimeDistCleaner.processClassWithFlags(RuntimeDistCleaner.java:57) ~[fmlloader-1.20.1-47.2.20.jar%2369!/:1.0] {}
	at cpw.mods.modlauncher.LaunchPluginHandler.offerClassNodeToPlugins(LaunchPluginHandler.java:88) ~[modlauncher-10.0.9.jar%2355!/:?] {}
	at cpw.mods.modlauncher.ClassTransformer.transform(ClassTransformer.java:120) ~[modlauncher-10.0.9.jar%2355!/:?] {}
	at cpw.mods.modlauncher.TransformingClassLoader.maybeTransformClassBytes(TransformingClassLoader.java:50) ~[modlauncher-10.0.9.jar%2355!/:?] {}
	at cpw.mods.cl.ModuleClassLoader.readerToClass(ModuleClassLoader.java:113) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.lambda$findClass$15(ModuleClassLoader.java:219) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.loadFromModule(ModuleClassLoader.java:229) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.findClass(ModuleClassLoader.java:219) ~[securejarhandler-2.1.10.jar:?] {}
	at cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:135) ~[securejarhandler-2.1.10.jar:?] {}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?] {}
	at weather2.weathersystem.storm.StormObject.spinEntityv2(StormObject.java:2462) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading,pl:runtimedistcleaner:A}
	at weather2.weathersystem.storm.TornadoHelper.forceRotate(TornadoHelper.java:706) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading,pl:runtimedistcleaner:A}
	at weather2.weathersystem.storm.TornadoHelper.forceRotate(TornadoHelper.java:648) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading,pl:runtimedistcleaner:A}
	at weather2.weathersystem.storm.TornadoHelper.tick(TornadoHelper.java:227) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading,pl:runtimedistcleaner:A}
	at weather2.weathersystem.storm.StormObject.tick(StormObject.java:744) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading,pl:runtimedistcleaner:A}
	at weather2.weathersystem.WeatherManager.tick(WeatherManager.java:64) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading}
	at weather2.weathersystem.WeatherManagerServer.tick(WeatherManagerServer.java:59) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading}
	at weather2.ServerTickHandler.tickServer(ServerTickHandler.java:68) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading}
	at weather2.__ServerTickHandler_tickServer_ServerTickEvent.invoke(.dynamic) ~[weather2-1.20.1-2.8.1.jar%23167!/:1.20.1-2.8.1] {re:classloading,pl:eventbus:B}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:73) ~[eventbus-6.0.5.jar%2352!/:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:315) ~[eventbus-6.0.5.jar%2352!/:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:296) ~[eventbus-6.0.5.jar%2352!/:?] {}
	at net.minecraftforge.event.ForgeEventFactory.onPreServerTick(ForgeEventFactory.java:945) ~[forge-1.20.1-47.2.20-universal.jar%23174!/:?] {re:classloading}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:812) ~[server-1.20.1-20230612.114412-srg.jar%23169!/:?] {re:classloading,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661) ~[server-1.20.1-20230612.114412-srg.jar%23169!/:?] {re:classloading,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251) ~[server-1.20.1-20230612.114412-srg.jar%23169!/:?] {re:classloading,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B}
```