### PR TITLE
Fix: Works incorrectly on blocks which has low hardness and can be break by axes

### DIFF
--- a/src/main/java/weather2/util/WeatherUtil.java
+++ b/src/main/java/weather2/util/WeatherUtil.java
@@ -199,10 +199,11 @@ public class WeatherUtil {
                     } else {
 
                         //float strVsBlock = block.getBlockHardness(block.defaultBlockState(), parWorld, new BlockPos(0, 0, 0)) - (((itemStr.getStrVsBlock(block.defaultBlockState()) - 1) / 4F));
-                        float strVsBlock = state.getDestroySpeed(parWorld, new BlockPos(0, 0, 0)) - (((itemStr.getDestroySpeed(block.defaultBlockState()) - 1) / 4F));
+                        float hardness = state.getDestroySpeed(parWorld, new BlockPos(0, 0, 0));
+                        float strVsBlock = hardness - ((itemStr.getDestroySpeed(block.defaultBlockState()) - 1) / 4F);
 
                         //System.out.println(strVsBlock);
-                        if (/*block.getHardness() <= 10000.6*/ (strVsBlock <= strMax && strVsBlock >= strMin) ||
+                        if (/*block.getHardness() <= 10000.6*/ (strVsBlock <= strMax && hardness >= 0.0F) ||
                                 (state.getBlock().defaultMapColor() == MapColor.WOOD) ||
                                 state.getBlock().defaultMapColor() == MapColor.WOOL ||
                                 state.getBlock().defaultMapColor() == MapColor.PLANT ||/*


### PR DESCRIPTION
A block which can be break by axes is able be grabbed when its hardness is between 1.75 and 2.49 but unable when its hardness under 1.75 (its calculated `strVsBlock` is negative). This is obviously incorrect, so this PR aims to fix this bug.