### PR TITLE
Use HashSet for caching

### DIFF
--- a/src/main/java/weather2/weathersystem/storm/StormObject.java
+++ b/src/main/java/weather2/weathersystem/storm/StormObject.java
@@ -208,7 +208,7 @@ public class StormObject extends WeatherObject {
 
 	public boolean isFirenado = false;
 
-	public List<LivingEntity> listEntitiesUnderClouds = new ArrayList<>();
+	public Set<LivingEntity> listEntitiesUnderClouds = new HashSet<>();
 
 	private boolean playerControlled = false;
 	private int playerControlledTimeLeft = 20;


### PR DESCRIPTION
Makes `listEntitiesUnderClouds` use a `HashSet` instead of `ArrayList`.